### PR TITLE
Wrong git instruction in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ If you want to use S3 upload Gaufrette has also submodules to initialize. Here i
 	cd YOUR-APP-FOLDER
 	git submodule add git://github.com/burzum/FileStorage.git Plugin/FileStorage
 	git submodule update --init
-	cd Plugin/FileStorage/Vendor/Gaufrette
+	cd Plugin/FileStorage
 	git submodule update --init
 
 If you do not want to add it as submodule just clone it instead of doing submodule add


### PR DESCRIPTION
I'm currently (trying to) test you plugin and found a (very minor) mistake in the readme.

If you do `git submodule update --init` from `MY-APP-FOLDER/Plugin/FileStorage/Vendor/Gaufrette`, git (v1.7.4.1) only answers this:

`You need to run this command from the toplevel of the working tree.`

So I changed the readme accordingly.
