### PR TITLE
Readme fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,10 @@ To be able to simply autoload Gaufrette load the plugin with bootstrap enabled. 
 
 	CakePlugin::load('FileStorage', array('bootstrap' => true));
 
+You also need to setup the plugin database :
+
+    cake schema create --plugin FileStorage
+
 This plugin depends on the Gaufrette library (https://github.com/KnpLabs/Gaufrette), init the submodule, the plugin depends on it.
 
 	git submodule update --init


### PR DESCRIPTION
- Update readme to use git init submodule recursive option
- Add database migration instruction
- Fix example PHP syntax

Also, not 100% sure about this one but I pretty sure if you set your form like this as in the exemple :

``` php
echo $this->Form->input('PdfFile.file');
```

You'll have to use file file key after in the controller or model logic handling upload unless there is some callback magics happening (did not happened to me) :

``` php
file_get_contents($this->data['PdfFile']**['file']**['tmp_name']
```
