### PR TITLE
Fixing error when No file was uploaded (or presumably other UploadError)

### DIFF
--- a/Model/Behavior/UploadValidatorBehavior.php
+++ b/Model/Behavior/UploadValidatorBehavior.php
@@ -89,7 +89,7 @@ class UploadValidatorBehavior extends ModelBehavior {
 		if ($validate === true && isset($Model->data[$Model->alias][$fileField]) && is_array($Model->data[$Model->alias][$fileField])) {
 
 			if ($Model->validateUploadError($Model->data[$Model->alias][$fileField]['error']) === false) {
-				$Model->validationErrors[$fileField] = $this->uploadError;
+				$Model->validationErrors[$fileField] = array($this->uploadError);
 				return false;
 			}
 


### PR DESCRIPTION
Without this fix I get the following error when trying to upload without selecting a file

`Warning (2): Invalid argument supplied for foreach()   [CORE/Cake/View/Helper/FormHelper.php, line 682]`

```
}
$tmp = array();
foreach ($error as &$e) {
```

`$error = 'No file was uploaded.'`

```
FormHelper::error() - CORE/Cake/View/Helper/FormHelper.php, line 682
FormHelper::input() - CORE/Cake/View/Helper/FormHelper.php, line 1005
include - APP/View/Profiles/picture.ctp, line 24
View::_evaluate() - CORE/Cake/View/View.php, line 947
View::_render() - CORE/Cake/View/View.php, line 909
View::render() - CORE/Cake/View/View.php, line 471
Controller::render() - CORE/Cake/Controller/Controller.php, line 948
Dispatcher::_invoke() - CORE/Cake/Routing/Dispatcher.php, line 194
Dispatcher::dispatch() - CORE/Cake/Routing/Dispatcher.php, line 162
[main] - APP/webroot/index.php, line 109
```
