### PR TITLE
Correct UploadValidator settings

### DIFF
--- a/Model/ImageStorage.php
+++ b/Model/ImageStorage.php
@@ -26,7 +26,7 @@ class ImageStorage extends FileStorage {
 		'Imagine.Imagine',
 		'FileStorage.UploadValidator' => array(
 			'localFile' => true,
-			'validateUpload' => false,
+			'validate' => false,
 			'allowedExtensions' => array('jpg', 'png', 'gif')
 		),
 	);


### PR DESCRIPTION
`validate` and not `validateUpload` is the key used in UploadValidator settings
