### PR TITLE
Duplicate error message when validateAllowedMimeTypes fails

### DIFF
--- a/Model/Behavior/UploadValidatorBehavior.php
+++ b/Model/Behavior/UploadValidatorBehavior.php
@@ -103,7 +103,6 @@ class UploadValidatorBehavior extends ModelBehavior {
 
 			if (is_array($allowedMime)) {
 				if (!$this->validateAllowedMimeTypes($Model, $allowedMime)) {
-					$Model->invalidate($fileField, $this->uploadError);
 					return false;
 				}
 			}


### PR DESCRIPTION
`$Model->invalidate($fileField, $this->uploadError)`
is already invoked in `validateAllowedMimeTypes` function (line 156)
