### PR TITLE
Add to packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "burzum/FileStorage",
+	"name": "burzum/file-storage",
 	"type": "cakephp-plugin",
 	"description": "This plugin is giving you the possibility to store files in virtually and kind of storage backend. This plugin is wrapping the Gaufrette library (https://github.com/KnpLabs/Gaufrette) library in a CakePHP fashion and provides a simple way to use the storage adapters through the StorageManager class.",
 	"keywords": ["file", "filesystem", "media", "abstraction", "upload", "cakephp", "storage"],


### PR DESCRIPTION
The current package name is not valid for http://packagist.org

With this change you could add this plugin to it and avoid users to a VCS repository entry to the composer.json :smile:
