### PR TITLE
Update Installation.md

### DIFF
--- a/docs/Documentation/Installation.md
+++ b/docs/Documentation/Installation.md
@@ -28,11 +28,11 @@ use Burzum\FileStorage\Event\LocalFileStorageListener;
 spl_autoload_register(__NAMESPACE__ .'\FileStorageUtils::gaufretteLoader');
 
 $listener = new LocalFileStorageListener();
-CakeEventManager::instance()->on($listener);
+EventManager::instance()->on($listener);
 
 // For automated image processing you'll have to attach this listener as well
 $listener = new ImageProcessingListener();
-CakeEventManager::instance()->on($listener);
+EventManager::instance()->on($listener);
 ```
 
 Adapter Specific Configuration


### PR DESCRIPTION
I'm running CakePHP 3.0.8 and it seems like the `CakeEventManager` has been renamed to `EventManager`