### PR TITLE
3.0 PathBuilderTrait and easy path/url access.

### DIFF
--- a/src/Model/Table/FileStorageTable.php
+++ b/src/Model/Table/FileStorageTable.php
@@ -10,6 +10,7 @@ use Cake\Log\LogTrait;
 use Cake\ORM\Table;
 use Cake\ORM\Entity;
 
+use Burzum\FileStorage\Storage\PathBuilder\PathBuilderTrait;
 use Burzum\FileStorage\Storage\StorageTrait;
 
 /**

--- a/src/Model/Table/FileStorageTable.php
+++ b/src/Model/Table/FileStorageTable.php
@@ -22,6 +22,7 @@ use Burzum\FileStorage\Storage\StorageTrait;
 class FileStorageTable extends Table {
 
 	use LogTrait;
+	use PathBuilderTrait;
 	use StorageTrait;
 
 /**
@@ -198,5 +199,29 @@ class FileStorageTable extends Table {
 			}
 		}
 		return false;
+	}
+
+/**
+ * Returns full file path for an entity.
+ *
+ * @param \Cake\Datasource\EntityInterface $entity
+ * @param array $options
+ * @return string
+ */
+	public function fullFilePath(EntityInterface $entity, array $options = []) {
+		$pathBuilder = $this->createPathBuilder($entity['adapter']);
+		return $pathBuilder->fullPath($entity, $options);
+	}
+
+/**
+ * Returns file url for an entity.
+ *
+ * @param \Cake\Datasource\EntityInterface $entity
+ * @param array $options
+ * @return string
+ */
+	public function fileUrl(EntityInterface $entity, array $options = []) {
+		$pathBuilder = $this->createPathBuilder($entity['adapter']);
+		return $pathBuilder->url($entity, $options);
 	}
 }

--- a/src/Storage/PathBuilder/LocalPathBuilder.php
+++ b/src/Storage/PathBuilder/LocalPathBuilder.php
@@ -10,4 +10,13 @@ use Cake\ORM\Entity;
 
 class LocalPathBuilder extends BasePathBuilder {
 
+/**
+ * Constructor
+ *
+ * @param array $config
+ */
+	public function __construct(array $config = array()) {
+		$this->_defaultConfig['modelFolder'] = true;
+		parent::__construct($config);
+	}
 }

--- a/src/Storage/PathBuilder/LocalPathBuilder.php
+++ b/src/Storage/PathBuilder/LocalPathBuilder.php
@@ -10,13 +10,4 @@ use Cake\ORM\Entity;
 
 class LocalPathBuilder extends BasePathBuilder {
 
-/**
- * Constructor
- *
- * @param array $config
- */
-	public function __construct(array $config = array()) {
-		$this->_defaultConfig['modelFolder'] = true;
-		parent::__construct($config);
-	}
 }

--- a/src/Storage/PathBuilder/PathBuilderTrait.php
+++ b/src/Storage/PathBuilder/PathBuilderTrait.php
@@ -35,7 +35,7 @@ trait PathBuilderTrait {
 			throw new RuntimeException(sprintf('Could not find path builder "%s"!', $className));
 		}
 		$pathBuilder = new $className($options);
-		if ($pathBuilder instanceof PathBuilderInterface) {
+		if (!$pathBuilder instanceof PathBuilderInterface) {
 			throw new RuntimeException(sprintf('Path builder class "%s" does not implement the PathBuilderInterface interface!', $className));
 		}
 		return $pathBuilder;

--- a/src/Storage/PathBuilder/PathBuilderTrait.php
+++ b/src/Storage/PathBuilder/PathBuilderTrait.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @author Florian Krämer
+ * @copyright 2012 - 2015 Florian Krämer
+ * @license MIT
+ */
+namespace Burzum\FileStorage\Storage\PathBuilder;
+
+use Cake\Core\App;
+use RuntimeException;
+
+trait PathBuilderTrait {
+
+/**
+ * Local PathBuilderInterface instance.
+ *
+ * @var \Burzum\FileStorage\Storage\PathBuilder\PathBuilderInterface
+ */
+	protected $_pathBuilder;
+
+/**
+ * Builds the path builder for given interface.
+ *
+ * @param string $name
+ * @param array $options
+ * @param bool $renewObject
+ * @return \Burzum\FileStorage\Storage\PathBuilder\PathBuilderInterface
+ */
+	public function createPathBuilder($name, array $options = []) {
+		$className = App::className($name, 'Storage/PathBuilder', 'PathBuilder');
+		if (!class_exists($className)) {
+			$className = App::className('Burzum/FileStorage.' . $name, 'Storage/PathBuilder', 'PathBuilder');
+		}
+		if (!class_exists($className)) {
+			throw new RuntimeException(sprintf('Could not find path builder "%s"!', $className));
+		}
+		$pathBuilder = new $className($options);
+		if ($pathBuilder instanceof PathBuilderInterface) {
+			throw new RuntimeException(sprintf('Path builder class "%s" does not implement the PathBuilderInterface interface!', $className));
+		}
+		return $pathBuilder;
+	}
+
+/**
+ * Accessor/mutator for local PathBuilderInterface instance.
+ *
+ * @param \Burzum\FileStorage\Storage\PathBuilder\PathBuilderInterface $pathBuilder
+ * @return \Burzum\FileStorage\Storage\PathBuilder\PathBuilderInterface
+ */
+	public function pathBuilder(PathBuilderInterface $pathBuilder = null) {
+		if ($pathBuilder !== null) {
+			$this->_pathBuilder = $pathBuilder;
+		}
+		return $this->_pathBuilder;
+	}
+}

--- a/src/Storage/PathBuilder/PathBuilderTrait.php
+++ b/src/Storage/PathBuilder/PathBuilderTrait.php
@@ -32,11 +32,11 @@ trait PathBuilderTrait {
 			$className = App::className('Burzum/FileStorage.' . $name, 'Storage/PathBuilder', 'PathBuilder');
 		}
 		if (!class_exists($className)) {
-			throw new RuntimeException(sprintf('Could not find path builder "%s"!', $className));
+			throw new RuntimeException(sprintf('Could not find path builder "%s"!', $name));
 		}
 		$pathBuilder = new $className($options);
 		if (!$pathBuilder instanceof PathBuilderInterface) {
-			throw new RuntimeException(sprintf('Path builder class "%s" does not implement the PathBuilderInterface interface!', $className));
+			throw new RuntimeException(sprintf('Path builder class "%s" does not implement the PathBuilderInterface interface!', $name));
 		}
 		return $pathBuilder;
 	}

--- a/tests/TestCase/Storage/PathBuilder/PathBuilderTraitTest.php
+++ b/tests/TestCase/Storage/PathBuilder/PathBuilderTraitTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace Burzum\FileStorage\Test\TestCase\Storage\PathBuilder;
+
+use Cake\TestSuite\TestCase;
+
+class PathBuilderTraitTest extends TestCase {
+
+/**
+ * Test createPathBuilder() method.
+ *
+ * @return void
+ */
+	public function testCreatePathBuilder() {
+		$object = $this->getObjectForTrait('Burzum\FileStorage\Storage\PathBuilder\PathBuilderTrait');
+
+		$pathBuilder = $object->createPathBuilder('Local');
+		$this->assertInstanceOf('Burzum\FileStorage\Storage\PathBuilder\PathBuilderInterface', $pathBuilder);
+		$this->assertInstanceOf('Burzum\FileStorage\Storage\PathBuilder\LocalPathBuilder', $pathBuilder);
+	}
+
+/**
+ * Test createPathBuilder() method with invalid class.
+ *
+ * @return void
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage Path builder class "\stdClass" does not implement the PathBuilderInterface interface!
+ */
+	public function testCreatePathBuilderInvalidClass() {
+		$object = $this->getObjectForTrait('Burzum\FileStorage\Storage\PathBuilder\PathBuilderTrait');
+
+		$object->createPathBuilder('\stdClass');
+	}
+
+/**
+ * Test createPathBuilder() method with missing class.
+ *
+ * @return void
+ * @expectedException RuntimeException
+ * @expectedExceptionMessage Could not find path builder "Foo"!
+ */
+	public function testCreatePathBuilderMissingClass() {
+		$object = $this->getObjectForTrait('Burzum\FileStorage\Storage\PathBuilder\PathBuilderTrait');
+
+		$object->createPathBuilder('Foo');
+	}
+
+/**
+ * Test pathBuilder() method.
+ *
+ * @return void
+ */
+	public function testPathBuilder() {
+		$object = $this->getObjectForTrait('Burzum\FileStorage\Storage\PathBuilder\PathBuilderTrait');
+		$pathBuilder = $this->getMock('Burzum\FileStorage\Storage\PathBuilder\PathBuilderInterface');
+
+		$object->pathBuilder($pathBuilder);
+		
+		$this->assertSame($pathBuilder, $object->pathBuilder());
+	}
+}


### PR DESCRIPTION
I've added `PathBuilderTrait` so classes can easily build and access path builders for various adapters.
I've also added some convenience methods to `FileStorageTable` for path and url building using this trait.

~~Additionally I updated LocaPathBuilder with default `modelFolder` option set to `true` as `LocalListener` seems to be needing that.~~ That was a mistake :)