### PR TITLE
Reworked building path with PathBuilder

### DIFF
--- a/src/Event/AbstractStorageEventListener.php
+++ b/src/Event/AbstractStorageEventListener.php
@@ -9,6 +9,7 @@ use Cake\Log\LogTrait;
 use Cake\ORM\Table;
 use Cake\Utility\Text;
 use Cake\Filesystem\Folder;
+use Burzum\FileStorage\Storage\PathBuilder\PathBuilderTrait;
 use Burzum\FileStorage\Storage\StorageManager;
 use Burzum\FileStorage\Storage\StorageUtils;
 
@@ -35,6 +36,7 @@ abstract class AbstractStorageEventListener implements EventListenerInterface {
 
 	use InstanceConfigTrait;
 	use LogTrait;
+	use PathBuilderTrait;
 
 /**
  * The adapter class
@@ -137,16 +139,9 @@ abstract class AbstractStorageEventListener implements EventListenerInterface {
  * @return string
  */
 	public function buildPath($table, $entity) {
-		$path = '';
-		if ($this->_config['tableFolder']) {
-			$path .= $table->table() . DS;
-		}
-		if ($this->_config['randomPath'] === true) {
-			$path .= StorageUtils::randomPath($entity[$table->primaryKey()]);
-		}
-		if ($this->_config['uuidFolder'] === true) {
-			$path .= $this->stripDashes($entity[$table->primaryKey()]) . DS;
-		}
+		$pathBuilder = $this->createPathBuilder($entity['adapter']);
+		$path = $pathBuilder->path($entity);
+
 		return $path;
 	}
 

--- a/src/Event/LocalFileStorageListener.php
+++ b/src/Event/LocalFileStorageListener.php
@@ -68,19 +68,6 @@ class LocalFileStorageListener extends AbstractStorageEventListener {
 	}
 
 /**
- * Builds the path under which the data gets stored in the storage adapter
- *
- * @param Table $table
- * @param Entity $entity
- * @return string
- */
-	public function buildPath($table, $entity) {
-		$path = parent::buildPath($table, $entity);
-		// Backward compatibility
-		return 'files' . DS . $path;
-	}
-
-/**
  * afterSave
  *
  * @param Event $event

--- a/src/Storage/PathBuilder/LocalPathBuilder.php
+++ b/src/Storage/PathBuilder/LocalPathBuilder.php
@@ -6,6 +6,39 @@
  */
 namespace Burzum\FileStorage\Storage\PathBuilder;
 
+use Burzum\FileStorage\Storage\StorageTrait;
+use Cake\Datasource\EntityInterface;
+
 class LocalPathBuilder extends BasePathBuilder {
 
+	use StorageTrait;
+
+/**
+ * Constructor
+ *
+ * Default options for compatibility reasons:
+ * - pathPrefix = 'files'
+ * - randomPath = 'crc32'
+ *
+ * @param array $config Configuration options.
+ */
+	public function __construct(array $config = []) {
+		$this->_defaultConfig['pathPrefix'] = 'files';
+		$this->_defaultConfig['randomPath'] = 'crc32';
+		parent::__construct($config);
+	}
+
+/**
+ * Returns the full filsystem path as defined in the storage adapter including filename.
+ *
+ * @param \Cake\Datasource\EntityInterface $entity
+ * @param array $options
+ * @return string
+ */
+	public function fullPath(EntityInterface $entity, array $options = []) {
+		$config = array_merge($this->config(), $options);
+
+		$storageConfig = $this->storageConfig($entity->get('adapter'));
+		return $storageConfig['adapterOptions'][0] . parent::fullPath($entity, $config);
+	}
 }

--- a/src/Storage/PathBuilder/LocalPathBuilder.php
+++ b/src/Storage/PathBuilder/LocalPathBuilder.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Florian Krämer
+ * @author Bernhard Picher
  * @copyright 2012 - 2015 Florian Krämer
  * @license MIT
  */

--- a/tests/TestCase/Event/AbstractStorageEventListenerTest.php
+++ b/tests/TestCase/Event/AbstractStorageEventListenerTest.php
@@ -129,7 +129,7 @@ class AbstractStorageEventListenerTest extends FileStorageTestCase {
 		$entity = $table->get('file-storage-1');
 
 		$result = $this->Listener->buildPath($table, $entity);
-		$this->assertEquals($result, '00' . DS . '14' . DS . '90' . DS . 'filestorage1' . DS);
+		$this->assertEquals($result, 'files' . DS . '00' . DS . '14' . DS . '90' . DS . 'filestorage1' . DS);
 	}
 
 }

--- a/tests/TestCase/Storage/PathBuilder/LocalPathBuilderTest.php
+++ b/tests/TestCase/Storage/PathBuilder/LocalPathBuilderTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Burzum\FileStorage\Test\TestCase\Storage\PathBuilder;
+
+use Burzum\FileStorage\Storage\PathBuilder\LocalPathBuilder;
+use Cake\Core\InstanceConfigTrait;
+use Cake\ORM\TableRegistry;
+use Cake\TestSuite\TestCase;
+
+class LocalPathBuilderTest extends TestCase {
+
+/**
+ * Fixtures
+ *
+ * @var array
+ */
+	public $fixtures = array(
+		'plugin.Burzum\FileStorage.FileStorage'
+	);
+
+	public function setUp() {
+		parent::setUp();
+		$this->FileStorage = TableRegistry::get('Burzum/FileStorage.FileStorage');
+		$this->entity = $this->FileStorage->newEntity([
+			'id' => 'file-storage-1',
+			'user_id' => 'user-1',
+			'foreign_key' => 'item-1',
+			'model' => 'Item',
+			'filename' => 'cake.icon.png',
+			'filesize' => '',
+			'mime_type' => 'image/png',
+			'extension' => 'png',
+			'hash' => '',
+			'path' => '',
+			'adapter' => 'Local',
+		]);
+		$this->entity->accessible('id', true);
+	}
+
+/**
+ * testPathbuilding
+ *
+ * @return void
+ */
+	public function testPathbuilding() {
+		$builder = new LocalPathBuilder();
+
+		$result = $builder->fullPath($this->entity);
+		$this->assertEquals($result, TMP . 'file-storage-test' . DS . 'files' . DS . '00' . DS . '14' . DS . '90' . DS . 'filestorage1' . DS . 'filestorage1.png');
+	}
+}


### PR DESCRIPTION
more usage of PathBuilderTrait
simplified path generation for local files
created LocalPathBuilder for generating full filesystem paths and adding options for compatibility reasons (pathPrefix, randomPath)
corrected test in AbstractStorageEventListener (was accepting path without prefix even if file is 'Local')