### PR TITLE
Return error messages and use them as message.

### DIFF
--- a/src/Event/ImageProcessingListener.php
+++ b/src/Event/ImageProcessingListener.php
@@ -310,7 +310,7 @@ class ImageProcessingListener extends AbstractStorageEventListener {
 			return $this->$buildMethod($Event);
 		}
 
-		throw new \RuntimeException(__d('file_storage', 'No callback image url callback implemented for adapter %s', $adapterClass));
+		throw new \RuntimeException(__d('file_storage', 'No callback image url callback implemented for adapter {0}', $adapterClass));
 	}
 
 /**

--- a/src/Model/Behavior/UploadValidatorBehavior.php
+++ b/src/Model/Behavior/UploadValidatorBehavior.php
@@ -103,7 +103,6 @@ class UploadValidatorBehavior extends Behavior {
 					'uploadErrors',
 					['allowNoFileError' => $config['allowNoFileError']]
 				],
-				'message' => __d('file_storage', 'No file was uploaded.')
 			]);
 		}
 		if ($config['validateUploadArray'] === true) {

--- a/src/Validation/UploadValidator.php
+++ b/src/Validation/UploadValidator.php
@@ -13,13 +13,6 @@ class UploadValidator extends Validator {
  *
  * @var string
  */
-	protected $_uploadError = '';
-
-/**
- * Upload error message after validation.
- *
- * @var string
- */
 	protected $_mimeType = '';
 
 /**
@@ -222,36 +215,26 @@ class UploadValidator extends Validator {
 				case UPLOAD_ERR_OK:
 					return true;
 				case UPLOAD_ERR_INI_SIZE:
-					$this->_uploadError = __d('file_storage', 'The uploaded file exceeds limit of %s.', Number::toReadableSize(ini_get('upload_max_filesize')));
-					return false;
+					return __d('file_storage', 'The uploaded file exceeds limit of %s.', Number::toReadableSize(ini_get('upload_max_filesize')));
 				case UPLOAD_ERR_FORM_SIZE:
-					$this->_uploadError = __d('file_storage', 'The uploaded file is to big, please choose a smaller file or try to compress it.');
-					return false;
+					return __d('file_storage', 'The uploaded file is to big, please choose a smaller file or try to compress it.');
 				case UPLOAD_ERR_PARTIAL:
-					$this->_uploadError = __d('file_storage', 'The uploaded file was only partially uploaded.');
-					return false;
+					return __d('file_storage', 'The uploaded file was only partially uploaded.');
 				case UPLOAD_ERR_NO_FILE:
 					if ($options['allowNoFileError'] === false) {
-						$this->_uploadError = __d('file_storage', 'No file was uploaded.');
-						return false;
+						return __d('file_storage', 'No file was uploaded.');
 					}
 					return true;
 				case UPLOAD_ERR_NO_TMP_DIR:
-					$this->_uploadError = __d('file_storage', 'The remote server has no temporary folder for file uploads. Please contact the site admin.');
-					return false;
+					return __d('file_storage', 'The remote server has no temporary folder for file uploads. Please contact the site admin.');
 				case UPLOAD_ERR_CANT_WRITE:
-					$this->_uploadError = __d('file_storage', 'Failed to write file to disk. Please contact the site admin.');
-					return false;
+					return __d('file_storage', 'Failed to write file to disk. Please contact the site admin.');
 				case UPLOAD_ERR_EXTENSION:
-					$this->_uploadError = __d('file_storage', 'File upload stopped by extension. Please contact the site admin.');
-					return false;
+					return __d('file_storage', 'File upload stopped by extension. Please contact the site admin.');
 				default:
-					$this->_uploadError = __d('file_storage', 'Unknown File Error. Please contact the site admin.');
-					return false;
+					return __d('file_storage', 'Unknown File Error. Please contact the site admin.');
 			}
-			return false;
 		}
-		$this->_uploadError = '';
 		return true;
 	}
 }

--- a/src/Validation/UploadValidator.php
+++ b/src/Validation/UploadValidator.php
@@ -215,7 +215,7 @@ class UploadValidator extends Validator {
 				case UPLOAD_ERR_OK:
 					return true;
 				case UPLOAD_ERR_INI_SIZE:
-					return __d('file_storage', 'The uploaded file exceeds limit of %s.', Number::toReadableSize(ini_get('upload_max_filesize')));
+					return __d('file_storage', 'The uploaded file exceeds limit of {0}.', Number::toReadableSize(ini_get('upload_max_filesize')));
 				case UPLOAD_ERR_FORM_SIZE:
 					return __d('file_storage', 'The uploaded file is to big, please choose a smaller file or try to compress it.');
 				case UPLOAD_ERR_PARTIAL:

--- a/tests/TestCase/Validation/UploadValidatorTest.php
+++ b/tests/TestCase/Validation/UploadValidatorTest.php
@@ -90,14 +90,14 @@ class UploadValidatorTest extends FileStorageTestCase {
  */
 	public function testUploadErrors() {
 		$this->assertTrue($this->Validator->uploadErrors(['error' => UPLOAD_ERR_OK]));
-		$this->assertFalse($this->Validator->uploadErrors(['error' => UPLOAD_ERR_INI_SIZE]));
-		$this->assertFalse($this->Validator->uploadErrors(['error' => UPLOAD_ERR_FORM_SIZE]));
-		$this->assertFalse($this->Validator->uploadErrors(['error' => UPLOAD_ERR_PARTIAL]));
-		$this->assertFalse($this->Validator->uploadErrors(['error' => UPLOAD_ERR_NO_FILE], ['allowNoFileError' => false]));
+		$this->assertInternalType('string', $this->Validator->uploadErrors(['error' => UPLOAD_ERR_INI_SIZE]));
+		$this->assertInternalType('string', $this->Validator->uploadErrors(['error' => UPLOAD_ERR_FORM_SIZE]));
+		$this->assertInternalType('string', $this->Validator->uploadErrors(['error' => UPLOAD_ERR_PARTIAL]));
+		$this->assertInternalType('string', $this->Validator->uploadErrors(['error' => UPLOAD_ERR_NO_FILE], ['allowNoFileError' => false]));
 		$this->assertTrue($this->Validator->uploadErrors(['error' => UPLOAD_ERR_NO_FILE], ['allowNoFileError' => true]));
-		$this->assertFalse($this->Validator->uploadErrors(['error' => UPLOAD_ERR_NO_TMP_DIR]));
-		$this->assertFalse($this->Validator->uploadErrors(['error' => UPLOAD_ERR_CANT_WRITE]));
-		$this->assertFalse($this->Validator->uploadErrors(['error' => UPLOAD_ERR_EXTENSION]));
+		$this->assertInternalType('string', $this->Validator->uploadErrors(['error' => UPLOAD_ERR_NO_TMP_DIR]));
+		$this->assertInternalType('string', $this->Validator->uploadErrors(['error' => UPLOAD_ERR_CANT_WRITE]));
+		$this->assertInternalType('string', $this->Validator->uploadErrors(['error' => UPLOAD_ERR_EXTENSION]));
 	}
 
 /**


### PR DESCRIPTION
Currently when validating the upload you the error message is set in the `$this->_uploadError` variable that isn't getting used anywhere.  Because the message is set [here](https://github.com/commercial-hippie/cakephp-file-storage/blob/1.1/src/Model/Behavior/UploadValidatorBehavior.php#L106) its not really helpful.

Instead if the error message gets returned the correct error message can be returned to the user.
