### PR TITLE
Fixes the consequences when saving empty file data.

### DIFF
--- a/src/Model/Table/FileStorageTable.php
+++ b/src/Model/Table/FileStorageTable.php
@@ -88,14 +88,13 @@ class FileStorageTable extends Table {
  * @return boolean true on success
  */
 	public function beforeSave(Event $event, EntityInterface $entity, $options) {
-		$Event = $this->dispatchEvent('FileStorage.beforeSave', array(
+		$storageEvent = $this->dispatchEvent('FileStorage.beforeSave', array(
 			'record' => $entity,
 			'storage' => $this->storageAdapter($entity['adapter'])
 		));
-		if ($Event->isStopped()) {
-			return false;
+		if ($storageEvent->isStopped()) {
+			$event->stopPropagation();
 		}
-		return true;
 	}
 
 /**
@@ -135,7 +134,7 @@ class FileStorageTable extends Table {
  * @param \Cake\Event\Event $event
  * @param \Cake\Datasource\EntityInterface $entity
  * @param array $options
- * @return boolean
+ * @return void
  */
 	public function afterSave(Event $event, EntityInterface $entity, $options) {
 		$this->dispatchEvent('FileStorage.afterSave', [
@@ -144,7 +143,6 @@ class FileStorageTable extends Table {
 			'storage' => $this->storageAdapter($entity['adapter'])
 		]);
 		$this->deleteOldFileOnSave($entity);
-		return true;
 	}
 
 /**
@@ -152,7 +150,7 @@ class FileStorageTable extends Table {
  *
  * @param \Cake\Event\Event $event
  * @param \Cake\Datasource\EntityInterface $entity
- * @return boolean
+ * @return void
  */
 	public function beforeDelete(Event $event, EntityInterface $entity) {
 		$this->record = $this->find()
@@ -163,10 +161,8 @@ class FileStorageTable extends Table {
 			->first();
 
 		if (empty($this->record)) {
-			return false;
+			$event->stopPropagation();
 		}
-
-		return true;
 	}
 
 /**
@@ -189,7 +185,7 @@ class FileStorageTable extends Table {
  * Deletes an old file to replace it with the new one if an old id was passed.
  *
  * Thought to be called in Model::afterSave() but can be used from any other
- * place as well like Model::beforeSave() as long as the field data is present.
+ * place as well like Table::beforeSave() as long as the field data is present.
  *
  * The old id has to be the UUID of the file_storage record that should be deleted.
  *

--- a/src/Model/Table/ImageStorageTable.php
+++ b/src/Model/Table/ImageStorageTable.php
@@ -50,19 +50,18 @@ class ImageStorageTable extends FileStorageTable {
  * @param \Cake\Event\Event $event
  * @param \Cake\Datasource\EntityInterface $entity
  * @param array $options
- * @return boolean true on success
+ * @return void
  */
 	public function beforeSave(Event $event, EntityInterface $entity, $options) {
-		if (!parent::beforeSave($event, $entity, $options)) {
-			return false;
+		if ($event->isStopped()) {
+			return;
 		}
 		$imageEvent = $this->dispatchEvent('ImageStorage.beforeSave', [
 			'record' => $entity
 		]);
 		if ($imageEvent->isStopped()) {
-			return false;
-}
-		return true;
+			$event->stopPropagation();
+		}
 	}
 
 /**
@@ -73,7 +72,7 @@ class ImageStorageTable extends FileStorageTable {
  * @param \Cake\Event\Event $event
  * @param \Cake\Datasource\EntityInterface $entity
  * @param array $options
- * @return boolean
+ * @return void
  */
 	public function afterSave(Event $event, EntityInterface $entity, $options) {
 		if ($entity->isNew()) {
@@ -83,7 +82,6 @@ class ImageStorageTable extends FileStorageTable {
 			]);
 			$this->deleteOldFileOnSave($entity);
 		}
-		return true;
 	}
 
 /**
@@ -91,11 +89,12 @@ class ImageStorageTable extends FileStorageTable {
  *
  * @param \Cake\Event\Event $event
  * @param \Cake\Datasource\EntityInterface $entity
- * @return boolean
+ * @return void
  */
 	public function beforeDelete(Event $event, EntityInterface $entity) {
-		if (!parent::beforeDelete($event, $entity)) {
-			return false;
+		parent::beforeDelete($event, $entity);
+		if ($event->isStopped()) {
+			return;
 		}
 
 		$imageEvent = $this->dispatchEvent('ImageStorage.beforeDelete', [
@@ -104,10 +103,8 @@ class ImageStorageTable extends FileStorageTable {
 		]);
 
 		if ($imageEvent->isStopped()) {
-			return false;
+			$event->stopPropagation();
 		}
-
-		return true;
 	}
 
 /**

--- a/src/Storage/Listener/LocalListener.php
+++ b/src/Storage/Listener/LocalListener.php
@@ -57,8 +57,10 @@ class LocalListener extends AbstractListener {
  */
 	public function implementedEvents() {
 		return array_merge(parent::implementedEvents(), [
+			'FileStorage.beforeSave' => 'beforeSaveCheckFileField',
 			'FileStorage.afterSave' => 'afterSave',
 			'FileStorage.afterDelete' => 'afterDelete',
+			'ImageStorage.beforeSave' => 'beforeSaveCheckFileField',
 			'ImageStorage.afterSave' => 'afterSave',
 			'ImageStorage.afterDelete' => 'afterDelete',
 			'ImageVersion.removeVersion' => 'removeImageVersion',
@@ -158,29 +160,6 @@ class LocalListener extends AbstractListener {
 		$this->_loadImageProcessingFromConfig();
 		$event->data['path'] = $event->result = $this->imageVersionPath($entity, $version, $type, $options);
 		$event->stopPropagation();
-	}
-
-/**
- * Stores the file in the configured storage backend.
- *
- * @param \Cake\Event\Event $event
- * @throws \Burzum\Filestorage\Storage\StorageException
- * @return boolean
- */
-	protected function _storeFile(Event $event) {
-		try {
-			$fileField = $this->config('fileField');
-			$entity = $event->data['record'];
-			$Storage = $this->storageAdapter($entity['adapter']);
-			$Storage->write($entity['path'], file_get_contents($entity[$fileField]['tmp_name']), true);
-			$event->result = $event->data['table']->save($entity, array(
-				'checkRules' => false
-			));
-			return true;
-		} catch (\Exception $e) {
-			$this->log($e->getMessage(), LogLevel::ERROR, ['scope' => ['storage']]);
-			throw new StorageException($e->getMessage());
-		}
 	}
 
 /**

--- a/src/View/Helper/ImageHelper.php
+++ b/src/View/Helper/ImageHelper.php
@@ -74,15 +74,16 @@ class ImageHelper extends Helper {
 		];
 
 		$event1 = new Event('ImageVersion.getVersions', $this, $eventOptions);
-		$event2 = new Event('FileStorage.ImageHelper.imagePath', $this, $eventOptions);
-
 		EventManager::instance()->dispatch($event1);
-		EventManager::instance()->dispatch($event2);
 
 		if ($event1->isStopped()) {
 			return $this->normalizePath($event1->data['path']);
-		} elseif ($event2->isStopped()) {
-			return $this->normalizePath($event2->data['path']);
+		} else {
+			$event2 = new Event('FileStorage.ImageHelper.imagePath', $this, $eventOptions);
+			EventManager::instance()->dispatch($event2);
+			if ($event2->isStopped()) {
+				return $this->normalizePath($event2->data['path']);
+			}
 		}
 		return false;
 	}

--- a/tests/TestCase/Storage/Listener/LocalListenerTest.php
+++ b/tests/TestCase/Storage/Listener/LocalListenerTest.php
@@ -48,6 +48,8 @@ class LocalListenerTest extends TestCase {
 	public function testimplementedEvents() {
 		$expected = [
 			'FileStorage.path' => 'getPath',
+			'FileStorage.beforeSave' => 'beforeSaveCheckFileField',
+			'ImageStorage.beforeSave' => 'beforeSaveCheckFileField',
 			'FileStorage.afterSave' => 'afterSave',
 			'FileStorage.afterDelete' => 'afterDelete',
 			'ImageStorage.afterSave' => 'afterSave',


### PR DESCRIPTION
When the file field is allowed to be empty and the storage entity is saved without a file present it was still saved successfully even in the case no file data was present. It also created an empty file in the storage backend (using the local adapter when I discovered this).

This commit should resolve these issues and improve the storage event system a little more.
