### PR TITLE
Fixed _buildAmazonS3Path in ImageProcessingListener

### DIFF
--- a/src/Event/ImageProcessingListener.php
+++ b/src/Event/ImageProcessingListener.php
@@ -351,8 +351,7 @@ class ImageProcessingListener extends AbstractStorageEventListener {
 	protected function _buildAmazonS3Path(Event $Event) {
 		extract($Event->data);
 
-		$path = $this->_buildPath($image, true, $hash);
-		$image['path'] = '/' . $path;
+		$path = '/' . $this->_buildPath($image, true, $hash);
 
 		$config = StorageManager::config($Event->data['image']['adapter']);
 		$bucket = $config['adapterOptions'][1];
@@ -367,10 +366,10 @@ class ImageProcessingListener extends AbstractStorageEventListener {
 			$http = 'https';
 		}
 
-		$image['path'] = str_replace('\\', '/', $image['path']);
+		$path = str_replace('\\', '/', $path);
 		$bucketPrefix = !empty($Event->data['options']['bucketPrefix']) && $Event->data['options']['bucketPrefix'] === true;
 
-		$Event->data['path'] = $Event->result = $this->_buildCloudFrontDistributionUrl($http, $image['path'], $bucket, $bucketPrefix, $cfDist);
+		$Event->data['path'] = $Event->result = $this->_buildCloudFrontDistributionUrl($http, $path, $bucket, $bucketPrefix, $cfDist);
 		$Event->stopPropagation();
 	}
 

--- a/tests/Fixture/FileStorageFixture.php
+++ b/tests/Fixture/FileStorageFixture.php
@@ -100,6 +100,21 @@ class FileStorageFixture extends TestFixture {
 			'adapter' => 'Local',
 			'created' => '2012-01-01 12:00:00',
 			'modified' => '2012-01-01 12:00:00',
+		),
+		array(
+			'id' => 'file-storage-4',
+			'user_id' => 'user-1',
+			'foreign_key' => 'item-4',
+			'model' => 'Item',
+			'filename' => 'titus.jpg',
+			'filesize' => '335872',
+			'mime_type' => 'image/jpg',
+			'extension' => 'jpg',
+			'hash' => '09d82a31',
+			'path' => null,
+			'adapter' => 'S3',
+			'created' => '2012-01-01 12:00:00',
+			'modified' => '2012-01-01 12:00:00',
 		)
 	);
 }


### PR DESCRIPTION
Image object should be immutable, otherwise it returns incorrect path when building it more than once for same image (and image passed by reference).
