### PR TITLE
Removed passed image parameter for auto rotate

### DIFF
--- a/src/Event/ImageProcessingListener.php
+++ b/src/Event/ImageProcessingListener.php
@@ -98,7 +98,7 @@ class ImageProcessingListener extends AbstractStorageEventListener {
 		$processor = new ImageProcessor();
 		$image = $processor->open($imageFile);
 		$processor->rotate($image, ['degree' => $degree]);
-		$image->save($imageFile, ['format' => $format]);
+		$image->save(['format' => $format]);
 		return true;
 	}
 


### PR DESCRIPTION
I already had this changes in a fork from a while back, think I forgot to create the issue for this.

This should solve #132.
