### PR TITLE
Memory limit issue

### DIFF
--- a/src/Storage/Listener/AbstractListener.php
+++ b/src/Storage/Listener/AbstractListener.php
@@ -310,7 +310,9 @@ abstract class AbstractListener implements EventListenerInterface {
 			$fileField = $this->config('fileField');
 			$entity = $event->data['entity'];
 			$Storage = $this->storageAdapter($entity['adapter']);
-			$Storage->write($entity['path'], file_get_contents($entity[$fileField]['tmp_name']), true);
+			$fileHandle = fopen($entity[$fileField]['tmp_name'], 'r');
+			$Storage->write($entity['path'], $fileHandle, true);
+			fclose($fileHandle);
 			$event->result = $event->data['table']->save($entity, array(
 				'checkRules' => false
 			));


### PR DESCRIPTION
Use a file resource instead of calling to `file_get_contents`, since that method load all the file in the memory, and for big files (200-900MB) throws a memory allocation error.