### PR TITLE
Only add a dot and hash to imageUrl is hash != null

### DIFF
--- a/src/View/Helper/ImageHelper.php
+++ b/src/View/Helper/ImageHelper.php
@@ -92,7 +92,11 @@ class ImageHelper extends StorageHelper {
 	public function imageUrl($image, $version = null, $options = []) {
 		$fileInfo = pathinfo($image['path']);
 		$hash = $this->_getHash($version, $image);
-		$version = $fileInfo['dirname'] . DS . $fileInfo['filename'] . '.' . $hash;
+		
+		$version = $fileInfo['dirname'] . DS . $fileInfo['filename'];       
+        if ($hash) {
+            $version .= '.' . $hash;
+        }
 
 		if (!empty($fileInfo['extension'])) {
 			$version .= '.' . $fileInfo['extension'];


### PR DESCRIPTION
I get double dots in filename if no version string is provided.